### PR TITLE
linux tweaks:

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -251,27 +251,7 @@ This may not do the correct thing in presence of links. If it does not find FILE
                    ""))))
   (call-interactively 'compile))
 
-;; Window resolution
-(defun set-size-according-to-resolution ()
-  (interactive)
-  (if (display-graphic-p)
-  (progn
-    ;; use 120 char wide window for largeish displays
-    ;; and smaller 80 column windows for smaller displays
-    ;; pick whatever numbers make sense for you
-    (if (> (x-display-pixel-width) 1280)
-           (add-to-list 'default-frame-alist (cons 'width 120))
-           (add-to-list 'default-frame-alist (cons 'width 80)))
-    ;; for the height, subtract a couple hundred pixels
-    ;; from the screen height (for panels, menubars and
-    ;; whatnot), then divide by the height of a char to
-    ;; get the height we want
-    (add-to-list 'default-frame-alist
-         (cons 'height (/ (- (x-display-pixel-height) 200)
-                             (frame-char-height)))))))
-
-(set-face-attribute 'default nil :height 170)
-(set-size-according-to-resolution)
+(set-face-attribute 'default nil :height 140)
 (set-frame-font "FiraCode Nerd Font" nil t)
 
 (defun smerge-or-next-error ()
@@ -302,7 +282,6 @@ PATTERN is the search pattern to use with rgrep."
 (global-set-key "\C-cg" 'goto-line)
 (global-set-key "\C-cj" 'smerge-or-next-error)
 (global-set-key "\C-ck" 'smerge-or-prev-error)
-(global-set-key "\C-cw" 'set-size-according-to-resolution)
 (global-set-key "\C-cr" 'query-replace-regexp)
 (global-set-key "\C-cd" 'gptel)
 (global-set-key "\C-cu" 'smerge-keep-upper)
@@ -310,6 +289,12 @@ PATTERN is the search pattern to use with rgrep."
 (global-set-key "\C-cm" 'smerge-mode)
 (global-set-key "\C-cf" 'interactive-rgrep)
 (global-set-key "\C-ca" 'aider-run-aider)
+
+;; copy and paste
+;; cmd-c and cmd-v are objectively better copy/paste shortcuts
+(global-set-key (kbd "<XF86Paste>") 'yank)
+(global-set-key (kbd "<XF86Copy>") 'kill-ring-save)
+(global-set-key (kbd "<XF86Cut>") 'kill-region)
 
 (setq gptel-model 'gpt-4.1
       gptel-backend (gptel-make-gh-copilot "Copilot"))

--- a/alacritty/alacritty.toml
+++ b/alacritty/alacritty.toml
@@ -1,5 +1,5 @@
 [font]
-size = 16.0
+size = 14.0
 
 [font.normal]
 family = "FiraCode Nerd Font"

--- a/sway/config
+++ b/sway/config
@@ -81,11 +81,17 @@ input "type:keyboard" {
     # Start a terminal
     bindsym $mod+Return exec $term
 
+    # copy and paste more like macos
+    bindsym Mod4+c exec wtype -k XF86Copy
+    bindsym Mod4+x exec wtype -k XF86Cut
+    bindsym Mod4+v exec wtype -k XF86Paste
+
     # Kill focused window
     bindsym $mod+Shift+q kill
 
     # Start your launcher
     bindsym $mod+d exec $menu
+    bindsym Mod4+space exec $menu
 
     # Drag floating windows by holding down $mod and left mouse button.
     # Resize them with right mouse button + $mod.
@@ -138,6 +144,7 @@ input "type:keyboard" {
     bindsym $mod+Shift+o move container to workspace next; workspace next;
     bindsym $mod+Shift+t exec ~/.cargo/bin/sway-new-workspace move;
     bindsym $mod+Shift+d exec ~/.cargo/bin/sway-new-workspace open; exec $menu;
+    bindsym Mod4+Shift+space exec ~/.cargo/bin/sway-new-workspace open; exec $menu;
     
 #
 # Layout stuff:

--- a/waybar/config
+++ b/waybar/config
@@ -50,7 +50,7 @@
             "critical": 15
         },
         // Connected to AC
-        "format": "  {icon}  {capacity}%", // Icon: bolt
+        "format": "{icon} {capacity}%",
         // Not connected to AC
         "format-discharging": "{icon}  {capacity}%",
         "format-icons": [

--- a/waybar/style.css
+++ b/waybar/style.css
@@ -53,8 +53,8 @@
 #waybar {
     background: #323232;
     color: white;
-    font-family: Hack Nerd Font, Cantarell, Noto Sans, sans-serif;
-    font-size: 13px;
+    font-family: FiraCode Nerd Font, Cantarell, Noto Sans, sans-serif;
+    font-size: 12px;
 }
 
 /* Each module */
@@ -100,10 +100,6 @@
 #battery.critical.discharging {
     animation-name: blink-critical;
     animation-duration: 2s;
-}
-
-#clock {
-    font-weight: bold;
 }
 
 #cpu {


### PR DESCRIPTION
- cmd+c and cmd+v are objectively the correct copy/paste shortcuts
- adjust fonts and sizes
- remove emacs window-sizing now that we use
  tiling window managers everywhere

Signed-off-by: Nick Santos <nick.santos@docker.com>
