### PR TITLE
emacs startup improvements

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -12,7 +12,7 @@
         go-mode
         rust-mode
         flycheck-rust
-        typescript-mode
+        typescript-ts-mode
         web-mode
         terraform-mode
         eslint-rc
@@ -46,31 +46,24 @@
 ;; install github copilot hooks
 (require 'vc-git)
 (use-package copilot
-  :vc (:url "https://github.com/copilot-emacs/copilot.el"
-            :rev :newest
-            :branch "main")
+  :ensure t
+  :defer t
+  :hook (prog-mode . copilot-mode)
+  :bind (:map copilot-completion-map
+              ("<tab>" . copilot-accept-completion)
+              ("TAB" . copilot-accept-completion)
+              ("C-<tab>" . copilot-accept-completion-by-word)
+              ("C-TAB" . copilot-accept-completion-by-word))
   :init
   (setq copilot-indent-offset-warning-disable t))
 
-;; for eat terminal backend (claude code)
-(use-package eat :ensure t)
-
-;; for vterm terminal backend (claude code)
-(use-package vterm :ensure t)
-
-;; claude code client
-(use-package claude-code :ensure t
-  :vc (:url "https://github.com/stevemolitor/claude-code.el"
-	    :rev :newest)
-  :config (claude-code-mode)
-  :bind-keymap ("C-c t" . claude-code-command-map))
+;; default to text mode for new buffers.
+;; by default, emacs loads new buffers in a lisp mode,
+;; which triggers the copilot hooks and causes a long startup time.
+(setq initial-major-mode 'text-mode)
 
 ;; authinfo creds for forge
 (setq auth-sources '("~/.authinfo"))
-
-(add-hook 'prog-mode-hook 'copilot-mode)
-(define-key copilot-completion-map (kbd "<tab>") 'copilot-accept-completion)
-(define-key copilot-completion-map (kbd "TAB") 'copilot-accept-completion)
 
 ;; UI
 (add-to-list 'default-frame-alist '(tool-bar-lines . t))
@@ -109,14 +102,15 @@
 (make-directory "~/.emacs.d/autosaves/" t)
 
 ;; protobuf mode
-(autoload 'protobuf-mode "protobuf-mode" nil t)
-(add-to-list 'auto-mode-alist '("\\.proto$" . protobuf-mode))
+(use-package protobuf-mode
+  :mode "\\.proto\\'")
 
 ;; go mode
-(autoload 'go-mode "go-mode" nil t)
-(add-to-list 'auto-mode-alist '("\\.go$" . go-mode))
-(setq gofmt-command "goimports")
-(setq gofmt-args '("-local" "github.com/tilt-dev"))
+(use-package go-mode
+  :mode "\\.go\\'"
+  :init
+  (setq gofmt-command "goimports")
+  (setq gofmt-args '("-local" "github.com/tilt-dev")))
 
 ;; json formatting
 ;; http://irreal.org/blog/?p=354
@@ -187,11 +181,13 @@
 (add-hook 'python-mode-hook 'add-trailing-whitespace-on-write-hook)
 (add-hook 'yaml-mode-hook 'add-trailing-whitespace-on-write-hook)
 (add-hook 'lua-mode-hook 'add-trailing-whitespace-on-write-hook)
-(add-hook 'typescript-mode-hook 'add-trailing-whitespace-on-write-hook)
+(add-hook 'typescript-ts-mode-hook 'add-trailing-whitespace-on-write-hook)
 
 ;; grep customization
 (with-eval-after-load 'grep
   (add-to-list 'grep-find-ignored-directories ".yarn")
+  (add-to-list 'grep-find-ignored-directories ".claude")
+  (add-to-list 'grep-find-ignored-directories ".specstory")
   (add-to-list 'grep-find-ignored-directories "node_modules")
   (add-to-list 'grep-find-ignored-directories "vendor"))
 
@@ -319,50 +315,55 @@ PATTERN is the search pattern to use with rgrep."
   (ansi-color-apply-on-region compilation-filter-start (point-max)))
 (add-hook 'compilation-filter-hook 'colorize-compilation-buffer)
 
-(require 'typescript-mode)
-(autoload 'typescript-mode "typescript-mode" nil t)
-(add-to-list 'auto-mode-alist '("\\.js$" . typescript-mode))
-(add-to-list 'auto-mode-alist '("\\.jsx$" . typescript-mode))
-(add-to-list 'auto-mode-alist '("\\.ts$" . typescript-mode))
-(add-to-list 'auto-mode-alist '("\\.tsx$" . typescript-mode))
-(add-to-list 'auto-mode-alist '("\\.json$" . typescript-mode))
+;; modern typescript mode
+(use-package typescript-ts-mode
+  :mode (("\\.js\\'" . typescript-ts-mode)
+         ("\\.jsx\\'" . tsx-ts-mode)
+         ("\\.ts\\'" . typescript-ts-mode)
+         ("\\.tsx\\'" . tsx-ts-mode)
+         ("\\.json\\'" . tsx-ts-mode))
+  :defer t)
 
-(require 'python-mode)
+(setq treesit-language-source-alist
+    '((typescript "https://github.com/tree-sitter/tree-sitter-typescript" "master" "typescript/src")
+      (tsx "https://github.com/tree-sitter/tree-sitter-typescript" "master" "tsx/src")))
 
+(require 'treesit)
+(dolist (lang '(typescript tsx))
+  (unless (treesit-ready-p lang)
+    (treesit-install-language-grammar lang)))
+
+(add-hook 'typescript-ts-mode-hook 'eglot-ensure)
+(add-hook 'tsx-ts-mode-hook 'eglot-ensure)
+
+(use-package python-mode
+  :mode "\\.py\\'"
+  :defer t)
 (define-derived-mode tiltfile-mode
   python-mode "tiltfile"
   "Major mode for Tilt Dev."
   (setq-local case-fold-search nil))
 
-(add-to-list 'auto-mode-alist '("Tiltfile$" . tiltfile-mode))
+(add-to-list 'auto-mode-alist '("Tiltfile\\'" . tiltfile-mode))
 
-(with-eval-after-load 'lsp-mode
-  (add-to-list 'lsp-language-id-configuration
-    '(tiltfile-mode . "tiltfile"))
+(use-package terraform-mode
+  :mode "\\.tf\\'")
 
+(use-package lsp-mode
+  :hook (tiltfile-mode . lsp)
+  :config
+  (add-to-list 'lsp-language-id-configuration '(tiltfile-mode . "tiltfile"))
   (lsp-register-client
     (make-lsp-client :new-connection (lsp-stdio-connection `("tilt" "lsp" "start"))
                      :activation-fn (lsp-activate-on "tiltfile")
-                     :server-id 'tilt-lsp)))
-
-(require 'terraform-mode)
-(autoload 'terraform-mode "terraform-mode" nil t)
-(add-to-list 'auto-mode-alist '("\\.tf$" . terraform-mode))
-
-(require 'lsp-mode)
-;;(add-hook 'typescript-mode-hook #'lsp)
-;;(add-hook 'web-mode-hook #'lsp)
-(add-hook 'tiltfile-mode-hook #'lsp)
-
-;; We usually edit monorepos where file watching won't work well.
-(setq lsp-enable-file-watchers nil)
-
-(defun lsp--eslint-before-save (orig-fun)
-  "Run lsp-eslint-apply-all-fixes and then run the original lsp--before-save."
-  (when lsp-eslint-auto-fix-on-save (lsp-eslint-fix-all))
-  (funcall orig-fun))
-
-(advice-add 'lsp--before-save :around #'lsp--eslint-before-save)
+                     :server-id 'tilt-lsp))
+  ;; We usually edit monorepos where file watching won't work well.
+  (setq lsp-enable-file-watchers nil)
+  (defun lsp--eslint-before-save (orig-fun)
+    "Run lsp-eslint-apply-all-fixes and then run the original lsp--before-save."
+    (when lsp-eslint-auto-fix-on-save (lsp-eslint-fix-all))
+    (funcall orig-fun))
+  (advice-add 'lsp--before-save :around #'lsp--eslint-before-save))
 
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
@@ -375,7 +376,7 @@ PATTERN is the search pattern to use with rgrep."
    '((claude-code :url "https://github.com/stevemolitor/claude-code.el")
      (copilot :url "https://github.com/copilot-emacs/copilot.el" :branch "main")))
  '(sh-basic-offset 2)
- '(typescript-indent-level 2))
+ '(typescript-ts-mode-indent-offset 2))
 
 (custom-set-faces
  ;; custom-set-faces was added by Custom.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	emacs --batch -l ~/.emacs -l $(PWD)/emacs-test.el -f ert-run-tests-batch-and-exit

--- a/emacs-test.el
+++ b/emacs-test.el
@@ -1,0 +1,81 @@
+;;; emacs-test.el --- ERT tests for .emacs configuration -*- lexical-binding: t; -*-
+
+;;; Commentary:
+;; Run with: emacs --batch -l ~/.emacs -l emacs-test.el -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+
+;;; Package tests
+;; Use `featurep' for packages that are explicitly `require'd in .emacs.
+;; Use `package-installed-p' for packages that are autoloaded/lazy-loaded.
+
+(ert-deftest config-test-flycheck-installed ()
+  "Flycheck should be installed (autoloaded, not eagerly required)."
+  (should (package-installed-p 'flycheck)))
+
+(ert-deftest config-test-magit-installed ()
+  "Magit should be installed (autoloaded, not eagerly required)."
+  (should (package-installed-p 'magit)))
+
+(ert-deftest config-test-go-mode-installed ()
+  "Go mode should be installed (autoloaded via `autoload', not eagerly required)."
+  (should (package-installed-p 'go-mode)))
+
+(ert-deftest config-test-exec-path-from-shell-loaded ()
+  "exec-path-from-shell should be loaded (explicitly required in .emacs)."
+  (should (featurep 'exec-path-from-shell)))
+
+;;; Custom function tests
+
+(ert-deftest config-test-custom-functions-defined ()
+  "All custom interactive functions should be defined."
+  (should (fboundp 'compile-command))
+  (should (fboundp 'format-json))
+  (should (fboundp 'format-json-region))
+  (should (fboundp 'interactive-rgrep))
+  (should (fboundp 'smerge-or-next-error))
+  (should (fboundp 'smerge-or-prev-error))
+  (should (fboundp 'untabify-buffer))
+  (should (fboundp 'colorize-compilation-buffer))
+  (should (fboundp 'sm-try-smerge))
+  (should (fboundp 'get-closest-pathname))
+  (should (fboundp 'get-best-build-descriptor)))
+
+;;; Variable tests
+
+(ert-deftest config-test-variables-set ()
+  "Key config variables should have expected values."
+  (should (equal gofmt-command "goimports"))
+  (should (equal (default-value 'flycheck-temp-prefix) ".flycheck"))
+  (should (equal (default-value 'tab-width) 2))
+  (should (equal (default-value 'indent-tabs-mode) nil))
+  (should (equal (default-value 'fill-column) 80)))
+
+;;; Auto-mode-alist tests
+
+(ert-deftest config-test-auto-mode-alist ()
+  "Expected file type associations should be registered."
+  (should (assoc "\\.go\\'" auto-mode-alist))
+  (should (assoc "\\.proto\\'" auto-mode-alist))
+  (should (assoc "\\.tf\\'" auto-mode-alist))
+  (should (assoc "\\.ts\\'" auto-mode-alist))
+  (should (assoc "\\.tsx\\'" auto-mode-alist))
+  (should (assoc "\\.js\\'" auto-mode-alist))
+  (should (assoc "\\.jsx\\'" auto-mode-alist))
+  (should (assoc "\\.json\\'" auto-mode-alist))
+  (should (assoc "Tiltfile\\'" auto-mode-alist)))
+
+;;; Keybinding tests
+
+(ert-deftest config-test-keybindings ()
+  "Global keybindings should be set."
+  (should (eq (global-key-binding (kbd "C-c c")) 'compile-command))
+  (should (eq (global-key-binding (kbd "C-c g")) 'goto-line))
+  (should (eq (global-key-binding (kbd "C-c j")) 'smerge-or-next-error))
+  (should (eq (global-key-binding (kbd "C-c k")) 'smerge-or-prev-error))
+  (should (eq (global-key-binding (kbd "C-c f")) 'interactive-rgrep))
+  (should (eq (global-key-binding (kbd "C-c r")) 'query-replace-regexp)))
+
+;;; emacs-test.el ends here

--- a/install.sh
+++ b/install.sh
@@ -12,3 +12,7 @@ for dir in environment.d sway; do
         ln -s "$(pwd)/$dir" "$HOME/.config/$dir"
     fi
 done
+
+if [[ ! -f ~/.config/starship.toml ]]; then
+    ln -s "$(pwd)/starship.toml" "$HOME/.config/starship.toml"
+fi

--- a/starship.toml
+++ b/starship.toml
@@ -1,0 +1,46 @@
+# Starship prompt configuration
+# https://starship.rs/config/
+
+command_timeout = 5000
+
+format = """
+$username\
+$hostname\
+$directory\
+$git_branch\
+$git_state\
+$git_status\
+$cmd_duration\
+$line_break\
+$python\
+$character"""
+
+[directory]
+truncation_length = 5
+truncate_to_repo = true
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"
+
+[git_branch]
+symbol = " "
+
+[git_status]
+conflicted = "⚠️ "
+ahead = "⇡${count}"
+behind = "⇣${count}"
+diverged = "⇕⇡${ahead_count}⇣${behind_count}"
+untracked = "?"
+stashed = "$"
+modified = "!"
+staged = "+"
+renamed = "»"
+deleted = "✘"
+
+[cmd_duration]
+min_time = 2_000
+format = "took [$duration]($style) "
+
+[python]
+symbol = " "


### PR DESCRIPTION
- defer-load all modes using new use-package
- enable typescript-ts-mode, which is the new new thing
- copilot is slow to load, so try to prevent
  loading it unless necessary
- add emacs init tests
- checkin a starship config

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
