### PR TITLE
aerospace: horizontal-only layout and key bindings

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -44,18 +44,14 @@ outer.right = 0
     alt-shift-q = 'close'
 
     # i3 wraps focus by default
-    alt-j =         'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors left'
-    alt-k =         'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors down'
-    alt-i =         'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors up'
-    alt-l = 'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors right'
+    alt-j = 'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors left'
+    alt-k = 'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors right'
 
     alt-shift-j = 'move left'
-    alt-shift-k = 'move down'
-    alt-shift-i = 'move up'
-    alt-shift-l = 'move right'
+    alt-shift-k = 'move right'
 
     alt-ctrl-shift-j = 'move-workspace-to-monitor --wrap-around left'
-    alt-ctrl-shift-l = 'move-workspace-to-monitor --wrap-around right'
+    alt-ctrl-shift-k = 'move-workspace-to-monitor --wrap-around right'
     
     alt-1 = 'workspace 1'
     alt-2 = 'workspace 2'
@@ -81,26 +77,17 @@ outer.right = 0
     alt-shift-9 = 'move-node-to-workspace 9 --focus-follows-window'
     alt-shift-0 = 'move-node-to-workspace 10 --focus-follows-window'
 
-    alt-t = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-new.sh'
-    alt-shift-t = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-move-to-new.sh'
-
-    alt-shift-y = 'exec-and-forget ~/src/dotfiles/bin/aerospace-sort-windows.sh'
-
-    alt-h = 'split horizontal'
-    alt-v = 'split vertical'
-
-    # alt-f used by emacs for forward-word
-    alt-shift-f = 'fullscreen'
-
     alt-s = 'layout v_accordion' # 'layout stacking' in i3
     alt-w = 'layout h_accordion' # 'layout tabbed' in i3
     alt-e = 'layout tiles horizontal vertical' # 'layout toggle split' in i3
 
-    alt-u = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev focus'
-    alt-o = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next focus'
+    alt-h = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev focus'
+    alt-l = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next focus'
+ 
+    alt-shift-h = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev move'
+    alt-shift-l = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next move'
 
-    alt-shift-u = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev move'
-    alt-shift-o = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next move'
+    alt-shift-t = 'exec-and-forget ~/src/dotfiles/bin/aerospace-sort-windows.sh'
 
     alt-shift-c = 'reload-config'
     alt-shift-b = 'exec-and-forget sketchybar --reload'

--- a/bin/aerospace-workspace-nav.sh
+++ b/bin/aerospace-workspace-nav.sh
@@ -13,6 +13,53 @@ if [[ "$action" != "focus" && "$action" != "move" ]]; then
   exit 1
 fi
 
+
+focused_window=$(aerospace list-windows --focused | cut -d' ' -f1 | tr -d ' ')
+
+shift_workspace_right_ignoring_focused() {
+  local from="$1"
+  local to="$(( from + 1 ))"
+
+  # base case: there are no windows to move in 'from'
+  local from_windows=$(aerospace list-windows --workspace "$from" | cut -d' ' -f1 | grep -v "$focused_window")
+  if [[ -z "$from_windows" ]]; then
+    return
+  fi
+
+  # shift the 'to' workspace out of the way
+  shift_workspace_right_ignoring_focused "$to"
+
+  # move all the windows
+  for win in $from_windows; do
+    aerospace move-node-to-workspace --window-id "$win" "$to"
+  done
+}
+
+# It's easier to think of this is 3 actions:
+# focus: find the next non-empty workspace, focus it
+# move (empty workspace): find the next non-empty workspace, move the focused window there
+# move (non-empty workspace): shift all the windows in this workspace out of the way
+if [[ "$action" == "move" ]]; then
+  focused_workspace=$(aerospace list-workspaces --focused | tr -d '\n')
+  count=$(aerospace list-windows --workspace "$focused_workspace" | wc -l | tr -d ' ')
+  if [[ "$count" != "1" ]]; then
+    
+    # handle the shift case
+    if [[ "$mode" == "prev" ]]; then
+      # Move all windows in the current workspace to the next workspace, so that
+      # the current window is alone.
+      shift_workspace_right_ignoring_focused "$focused_workspace"
+    else
+      # Move all windows in the next workspace to make way for this window.
+      shift_workspace_right_ignoring_focused "$(( focused_workspace + 1 ))"
+      aerospace move-node-to-workspace --focus-follows-window "$(( focused_workspace + 1 ))"
+    fi
+    exit 0
+    
+  fi
+fi
+
+# focus and move actions: search for the workspace we want
 focused=$(aerospace list-workspaces --focused | tr -d '\n')
 first="0"
 next="0"


### PR DESCRIPTION
- j/k navigate within a workspace
- h/l navigate between workspaces
- move-to-new-workspace semantics have changed
  - if the focused window shares a workspace, it should move to its own workspace
  - if the focused window is in its own workspace, it should move to a shared workspace

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
