### PR TITLE
aerospace: simplify navigation

### DIFF
--- a/.aerospace.toml
+++ b/.aerospace.toml
@@ -44,12 +44,12 @@ outer.right = 0
     # kill focused window
     alt-shift-q = 'close'
 
-    # i3 wraps focus by default
-    alt-j = 'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors left'
-    alt-k = 'focus --boundaries all-monitors-outer-frame --boundaries-action wrap-around-all-monitors right'
+    # focus/move: try within the workspace, then cross-workspace at the edge
+    alt-j = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh left focus'
+    alt-k = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh right focus'
 
-    alt-shift-j = 'move left'
-    alt-shift-k = 'move right'
+    alt-shift-j = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh left move'
+    alt-shift-k = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh right move'
 
     alt-ctrl-shift-j = 'move-workspace-to-monitor --wrap-around left'
     alt-ctrl-shift-k = 'move-workspace-to-monitor --wrap-around right'
@@ -64,8 +64,7 @@ outer.right = 0
     alt-8 = 'workspace 8'
     alt-9 = 'workspace 9'
     alt-0 = 'workspace 10'
-    # Workspaces 11+ are reachable via alt-u/alt-o (prev/next non-empty)
-    # or by creating new ones with alt-t.
+    # Workspaces 11+ are reachable by walking off the edge with alt-j/alt-k.
 
     alt-shift-1 = 'move-node-to-workspace 1 --focus-follows-window'
     alt-shift-2 = 'move-node-to-workspace 2 --focus-follows-window'
@@ -81,12 +80,6 @@ outer.right = 0
     alt-s = 'layout v_accordion' # 'layout stacking' in i3
     alt-w = 'layout h_accordion' # 'layout tabbed' in i3
     alt-e = 'layout tiles horizontal vertical' # 'layout toggle split' in i3
-
-    alt-h = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev focus'
-    alt-l = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next focus'
- 
-    alt-shift-h = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh prev move'
-    alt-shift-l = 'exec-and-forget ~/src/dotfiles/bin/aerospace-workspace-nav.sh next move'
 
     alt-shift-t = 'exec-and-forget ~/src/dotfiles/bin/aerospace-sort-windows.sh'
 

--- a/bin/aerospace-workspace-nav.sh
+++ b/bin/aerospace-workspace-nav.sh
@@ -1,16 +1,29 @@
 #!/bin/bash
 
 # Takes two arguments:
-# aerospace-workspace-helper.sh <prev|next> <focus|move>
-mode="$1"
+# aerospace-workspace-nav.sh <left|right> <focus|move>
+#
+# First tries an in-workspace focus/move via aerospace's native command.
+# If that hits the workspace boundary, falls through to cross-workspace:
+#   focus: focus the prev/next non-empty workspace
+#   move (single window): move to the prev/next non-empty workspace
+#   move (multiple windows): peel the focused window into its own workspace
+#                            by shifting the rest out of the way
+dir="$1"
 action="$2"
-if [[ "$mode" != "prev" && "$mode" != "next" ]]; then
-  echo "Invalid mode: $mode. Use 'prev' or 'next'."
-  exit 1
-fi
+case "$dir" in
+  left)  mode="prev" ;;
+  right) mode="next" ;;
+  *) echo "Invalid direction: $dir. Use 'left' or 'right'."; exit 1 ;;
+esac
 if [[ "$action" != "focus" && "$action" != "move" ]]; then
   echo "Invalid action: $action. Use 'focus' or 'move'."
   exit 1
+fi
+
+# In-workspace attempt. Exits 0 on success; falls through on boundary.
+if aerospace "$action" --boundaries workspace --boundaries-action fail "$dir" 2>/dev/null; then
+  exit 0
 fi
 
 
@@ -43,7 +56,7 @@ if [[ "$action" == "move" ]]; then
   focused_workspace=$(aerospace list-workspaces --focused | tr -d '\n')
   count=$(aerospace list-windows --workspace "$focused_workspace" | wc -l | tr -d ' ')
   if [[ "$count" != "1" ]]; then
-    
+
     # handle the shift case
     if [[ "$mode" == "prev" ]]; then
       # Move all windows in the current workspace to the next workspace, so that
@@ -55,7 +68,7 @@ if [[ "$action" == "move" ]]; then
       aerospace move-node-to-workspace --focus-follows-window "$(( focused_workspace + 1 ))"
     fi
     exit 0
-    
+
   fi
 fi
 
@@ -94,4 +107,3 @@ if [[ "$action" == "focus" ]]; then
 else
   aerospace move-node-to-workspace --focus-follows-window "$first"
 fi
-


### PR DESCRIPTION
before this pr, we had separate keyboard shortcuts
for "move focus to the next window in this workspace" and "move focus
to the next workspace". we also had separate keyboard shortcuts
for "move this window to the right in this workspace" and "move this
window to the next workspace"

now, we have a simpler set of keyboard shortcuts:
- focus left
- focus right
- move left
- move right

and the navigation script figures out if that should
be an in-workspace focus/move or a cross-workspace focus/move

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
